### PR TITLE
Adds and exposes counter of pending writes to store

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ function ImmediateStore (store) {
   if (!(this instanceof ImmediateStore)) return new ImmediateStore(store)
 
   this.store = store
+  this.pending = 0
   this.chunkLength = store.chunkLength
 
   if (!this.store || !this.store.get || !this.store.put) {
@@ -16,7 +17,9 @@ function ImmediateStore (store) {
 ImmediateStore.prototype.put = function (index, buf, cb) {
   var self = this
   self.mem[index] = buf
+  self.pending++
   self.store.put(index, buf, function (err) {
+    self.pending--
     self.mem[index] = null
     if (cb) cb(err)
   })

--- a/test.js
+++ b/test.js
@@ -21,6 +21,8 @@ test('put then immediate get', function (t) {
   store.get(0, function (err, data) {
     t.error(err)
     t.deepEqual(data, Buffer.from('0123456789'))
+    // May throw error on fast stores like MemoryChunkStore.
+    t.equal(store.pending, 1)
     didGet1 = true
     maybeDone()
   })
@@ -32,6 +34,7 @@ test('put then immediate get', function (t) {
     store.get(0, function (err, data) {
       t.error(err)
       t.deepEqual(data, Buffer.from('0123456789'))
+      t.equal(store.pending, 0)
       didGet2 = true
       maybeDone()
     })


### PR DESCRIPTION
Hey @feross,

This pull request creates and exposes a variable called `pending`,
`pending` is a simple counter which tracks the number of pending writes from `mem` to `store`.

Currently it is hard to track the number of chunks remaining in `mem` as the array is nulled, but it's length stays intact, this variable makes it easier to track without having to iterate over the entire `mem` array each time. 

My intended uses of `pending` include backpressure when read streams are too fast and the ability to know all chunks have been written to the store before destroying it.

A basic test is also included.

All the best.
